### PR TITLE
Fix #55 sys_als_ars.lua:304

### DIFF
--- a/addons/metrostroi/lua/metrostroi/systems/sys_als_ars.lua
+++ b/addons/metrostroi/lua/metrostroi/systems/sys_als_ars.lua
@@ -301,7 +301,7 @@ function TRAIN_SYSTEM:MoscowARS(EnableARS,KRUEnabled,BPSWorking,EnableUOS,EPKAct
 		if self.SpeedLimit == 40 and self.Special and self.NextLimit == self.SpeedLimit and (not self.Train.ARSType or self.Train.ARSType <= 2) and GetConVarNumber("metrostroi_ars_sfreq") > 0 and self.Train.SubwayTrain.Name == "81-717.5m" then
 			self.LN = true
 		end
-		if (self.Train.ARSType and self.Train.ARSType > 2) or GetConVarNumber("metrostroi_ars_sfreq") == 0 or self.Train.SubwayTrain.Name ~= "81-717.5m" then
+		if (self.Train.ARSType and self.Train.ARSType > 2) or GetConVarNumber("metrostroi_ars_sfreq") == 0 or (self.Train.SubwayTrain and self.Train.SubwayTrain.Name ~= "81-717.5m") then
 			self.LN = false
 		end
 		--Train.RPB:TriggerInput("Set",1)


### PR DESCRIPTION
[ERROR] addons/metrostroi/lua/metrostroi/systems/sys_als_ars.lua:304: attempt to index field 'SubwayTrain' (a nil value)

MoscowARS - addons/metrostroi/lua/metrostroi/systems/sys_als_ars.lua:304
Think - addons/metrostroi/lua/metrostroi/systems/sys_als_ars.lua:844
unknown - addons/metrostroi/lua/entities/gmod_subway_base/init.lua:1654