### PR TITLE
Fix 2 #55

### DIFF
--- a/addons/metrostroi/lua/metrostroi/systems/sys_als_ars.lua
+++ b/addons/metrostroi/lua/metrostroi/systems/sys_als_ars.lua
@@ -298,7 +298,7 @@ end
 function TRAIN_SYSTEM:MoscowARS(EnableARS,KRUEnabled,BPSWorking,EnableUOS,EPKActivated)
 	local Train = self.Train
 	if EnableARS then
-		if self.SpeedLimit == 40 and self.Special and self.NextLimit == self.SpeedLimit and (not self.Train.ARSType or self.Train.ARSType <= 2) and GetConVarNumber("metrostroi_ars_sfreq") > 0 and self.Train.SubwayTrain.Name == "81-717.5m" then
+		if self.SpeedLimit == 40 and self.Special and self.NextLimit == self.SpeedLimit and (not self.Train.ARSType or self.Train.ARSType <= 2) and GetConVarNumber("metrostroi_ars_sfreq") > 0 and (self.Train.SubwayTrain and self.Train.SubwayTrain.Name == "81-717.5m") then
 			self.LN = true
 		end
 		if (self.Train.ARSType and self.Train.ARSType > 2) or GetConVarNumber("metrostroi_ars_sfreq") == 0 or (self.Train.SubwayTrain and self.Train.SubwayTrain.Name ~= "81-717.5m") then
@@ -788,7 +788,7 @@ function TRAIN_SYSTEM:Think(dT)
 		if self.Signal70 then Vlimit = 70 end
 		if self.Signal80 then Vlimit = 80 end
 
-		if not self.LN and Vlimit > 40 and GetConVarNumber("metrostroi_ars_sfreq") > 0 and (not self.Train.ARSType or self.Train.ARSType <= 2) and self.Train.SubwayTrain.Name == "81-717.5m" then
+		if not self.LN and Vlimit > 40 and GetConVarNumber("metrostroi_ars_sfreq") > 0 and (not self.Train.ARSType or self.Train.ARSType <= 2) and (self.Train.SubwayTrain and self.Train.SubwayTrain.Name == "81-717.5m") then
 			VLimit2 = Vlimit
 			Vlimit = Vlimit < 40 and 0 or 40
 		end


### PR DESCRIPTION
[ERROR] addons/metrostroi/lua/metrostroi/systems/sys_als_ars.lua:301: attempt to index field 'SubwayTrain' (a nil value)

MoscowARS - addons/metrostroi/lua/metrostroi/systems/sys_als_ars.lua:301
Think - addons/metrostroi/lua/metrostroi/systems/sys_als_ars.lua:844
unknown - addons/metrostroi/lua/entities/gmod_subway_base/init.lua:1654
[ERROR] addons/metrostroi/lua/metrostroi/systems/sys_als_ars.lua:791: attempt to index field 'SubwayTrain' (a nil value)

Think - addons/metrostroi/lua/metrostroi/systems/sys_als_ars.lua:791
unknown - addons/metrostroi/lua/entities/gmod_subway_base/init.lua:1654